### PR TITLE
Logs of varying degrees of verbosity

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,7 +20,10 @@ To use the tool, you need to specify the following parameters:
 - `replication_url`: (optional, default <https://planet.osm.org/replication/>) The URL of the replication server. This should be in the format "<https://download.openstreetmap.fr/replication/europe/poland/lodzkie/minute/>".
 - options:
   - `--osm-like[=<true|false>]`: (optional, default true) If this flag is set, the tool will use the OSM-like URL format for the replication server. This is useful if you are using a server that does not follow the standard replication system.
-  - `--help`: (optional) If this flag is set, the tool will display the help message and exit.
+  - `--help|-h`: (optional) If this flag is set, the tool will display the help message and exit.
+  - `--log-level=<level>`: (optional, default "info") Set the log level for the tool. The available levels are "debug", "info", "warning", "error", and "fatal". This can be useful for debugging or for getting more information about the tool's operation.
+  - `--verbose|-v`: (optional) Verbose is an equivalent to `--log-level=debug`. It will output more information about the tool's operation.
+  - `--quiet|-q`: (optional) Quiet is an equivalent to `--log-level=error`. It will suppress all output except for errors. This can be useful if you only want to see error messages and nothing else.
 
 ## Example
 
@@ -28,6 +31,21 @@ Simple request for a state file for a specific day that is stored on the default
 
 ```bash
 ./osm-diff-state.sh day "2025-05-16"
+```
+
+```log
+[2025-05-27 09:52:07] INFO: Script parameters - Period: day, Timestamp: 2025-05-16
+[2025-05-27 09:52:07] INFO: Using URL: https://planet.osm.org/replication/
+[2025-05-27 09:52:07] INFO: Parsing and preparing base URL
+[2025-05-27 09:52:07] INFO: URL parsing completed successfully: 'https://planet.osm.org/replication/' -> 'https://planet.osm.org/replication/day/'
+[2025-05-27 09:52:07] INFO: Effective base URL: https://planet.osm.org/replication/day/
+[2025-05-27 09:52:07] INFO: Checking URL accessibility: https://planet.osm.org/replication/day/
+[2025-05-27 09:52:07] INFO: Fetching latest sequence number from: https://planet.osm.org/replication/day/state.txt
+[2025-05-27 09:52:07] INFO: Fetching latest timestamp from: https://planet.osm.org/replication/day/state.txt
+[2025-05-27 09:52:08] INFO: Starting binary search with bounds: [4629, 4640]
+[2025-05-27 09:52:09] INFO: Binary search found sequence number: 4629
+[2025-05-27 09:52:10] INFO: Final result URL: https://planet.osm.org/replication/day/000/004/629.state.txt
+https://planet.osm.org/replication/day/000/004/629.state.txt
 ```
 
 Example with explicit URL that is following the OSM-like URL format:

--- a/lib/date_.sh
+++ b/lib/date_.sh
@@ -13,9 +13,12 @@ to_epoch() {
     local input_date_string="${1%Z}" # Remove 'Z' suffix if present, as `date` handles UTC interpretation.
     input_date_string="${input_date_string/T/ }" # Replace 'T' with space for compatibility with `date` command.
 
+    log_debug "Converting date string: '$1' -> processed: '$input_date_string'"
+
     # Internal error reporting function for to_epoch
     _to_epoch_error() {
-        echo "Error (to_epoch): Invalid date format '$1'. Use YYYY-MM-DD[THH[:MM[:SS]]][Z]" >&2
+        local error_msg="Invalid date format '$1'. Use YYYY-MM-DD[THH[:MM[:SS]]][Z]"
+        log_error "$error_msg"
         return 1
     }
 
@@ -25,6 +28,8 @@ to_epoch() {
         local fmt # Loop variable for format strings
         local epoch_time # Stores the result of date conversion
 
+        log_debug "Attempting to parse date using macOS/BSD date syntax: '$date_to_parse'"
+
         # Order formats from most specific to least specific
         for fmt in \
             "%Y-%m-%d %H:%M:%S" \
@@ -32,12 +37,17 @@ to_epoch() {
             "%Y-%m-%d %H" \
             "%Y-%m-%d"
         do
+            log_debug "Trying format: '$fmt'"
             epoch_time=$(date -j -f "$fmt" "$date_to_parse" "+%s" 2>/dev/null)
             if [ $? -eq 0 ]; then
+                log_debug "Successfully parsed with format '$fmt' -> epoch: $epoch_time"
                 echo "$epoch_time"
                 return 0
+            else
+                log_debug "Format '$fmt' could not be applied to the timestamp '$date_to_parse'"
             fi
         done
+        log_warn "All macOS/BSD date formats failed for: '$date_to_parse'"
         return 1 # Failed to parse with any format
     }
 
@@ -46,27 +56,38 @@ to_epoch() {
         local date_to_parse="$1"
         local epoch_time # Stores the result of date conversion
 
+        log_debug "Attempting to parse timestamp using Linux/GNU date syntax: '$date_to_parse'"
+
         epoch_time=$(date -d "$date_to_parse" "+%s" 2>/dev/null)
         if [ $? -eq 0 ]; then
+            log_debug "Successfully parsed with GNU date -> epoch: $epoch_time"
             echo "$epoch_time"
             return 0
         else
+            log_warn "GNU date parsing failed for: '$date_to_parse'"
             return 1 # Failed to parse
         fi
     }
 
     local parsed_epoch
+    local system_type="$(uname)"
 
-    if [[ "$(uname)" == "Darwin" ]]; then
+    log_debug "Detected system type: $system_type"
+
+    if [[ "$system_type" == "Darwin" ]]; then
+        log_debug "Using macOS/BSD date parsing"
         parsed_epoch=$(_try_parse_mac "$input_date_string")
     else
+        log_debug "Using Linux/GNU date parsing"
         parsed_epoch=$(_try_parse_linux "$input_date_string")
     fi
 
     if [ -n "$parsed_epoch" ]; then
+        log_debug "Successfully converted '$1' to epoch timestamp: $parsed_epoch"
         echo "$parsed_epoch"
         return 0
     else
+        log_error "Failed to parse timestamp string: '$1'"
         _to_epoch_error "$1" # Pass original input for error message
         return 1
     fi

--- a/lib/logging_.sh
+++ b/lib/logging_.sh
@@ -1,0 +1,123 @@
+#!/bin/bash
+
+# Logging library with 5 levels: DEBUG, INFO, WARN, ERROR, FATAL
+# All log messages go to stderr to avoid interfering with script output to stdout
+
+# Log levels (numeric values for comparison)
+readonly LOG_LEVEL_DEBUG=0
+readonly LOG_LEVEL_INFO=1
+readonly LOG_LEVEL_WARN=2
+readonly LOG_LEVEL_ERROR=3
+readonly LOG_LEVEL_FATAL=4
+
+# Default log level (can be overridden)
+LOG_LEVEL=${LOG_LEVEL:-$LOG_LEVEL_INFO}
+
+# Color codes for different log levels (if terminal supports colors)
+if [[ -t 2 ]] && command -v tput >/dev/null 2>&1; then
+    readonly COLOR_DEBUG="\033[36m"    # Cyan
+    readonly COLOR_INFO="\033[32m"     # Green
+    readonly COLOR_WARN="\033[33m"     # Yellow
+    readonly COLOR_ERROR="\033[31m"    # Red
+    readonly COLOR_FATAL="\033[35m"    # Magenta
+    readonly COLOR_RESET="\033[0m"     # Reset
+else
+    readonly COLOR_DEBUG=""
+    readonly COLOR_INFO=""
+    readonly COLOR_WARN=""
+    readonly COLOR_ERROR=""
+    readonly COLOR_FATAL=""
+    readonly COLOR_RESET=""
+fi
+
+# Convert log level name to numeric value
+# Arguments:
+#   $1 - Log level name (debug, info, warn, error, fatal - case insensitive)
+# Output:
+#   Prints numeric log level to stdout
+# Returns:
+#   0 on success, 1 if invalid level name
+log_level_to_numeric() {
+    # local level_name="${1,,}" # Convert to lowercase in Baah 4.0
+    local level_name="$(echo $1 | tr '[:upper:]' '[:lower:]' )" # Convert to lowercase in Bash and Zsh
+
+    case "$level_name" in
+        debug) echo $LOG_LEVEL_DEBUG ;;
+        info)  echo $LOG_LEVEL_INFO ;;
+        warn)  echo $LOG_LEVEL_WARN ;;
+        error) echo $LOG_LEVEL_ERROR ;;
+        fatal) echo $LOG_LEVEL_FATAL ;;
+        *) return 1 ;;
+    esac
+    return 0
+}
+
+# Set the global log level
+# Arguments:
+#   $1 - Log level (debug, info, warn, error, fatal - case insensitive)
+# Returns:
+#   0 on success, 1 if invalid level
+set_log_level() {
+    local new_level
+    new_level=$(log_level_to_numeric "$1")
+    if [ $? -eq 0 ]; then
+        LOG_LEVEL=$new_level
+        return 0
+    else
+        echo "Error: Invalid log level '$1'. Valid levels: debug, info, warn, error, fatal" >&2
+        return 1
+    fi
+}
+
+# Internal function to log a message
+# Arguments:
+#   $1 - Numeric log level
+#   $2 - Log level name
+#   $3 - Color code
+#   $4 - Message
+_log() {
+    local msg_level="$1"
+    local level_name="$2"
+    local color="$3"
+    local message="$4"
+
+    # Only log if message level is >= current log level
+    if [ "$msg_level" -ge "$LOG_LEVEL" ]; then
+        local timestamp
+        timestamp=$(date '+%Y-%m-%d %H:%M:%S')
+        printf "${color}[%s] %s: %s${COLOR_RESET}\n" "$timestamp" "$level_name" "$message" >&2
+    fi
+}
+
+# Logging functions for each level
+log_debug() {
+    _log $LOG_LEVEL_DEBUG "DEBUG" "$COLOR_DEBUG" "$*"
+}
+
+log_info() {
+    _log $LOG_LEVEL_INFO "INFO" "$COLOR_INFO" "$*"
+}
+
+log_warn() {
+    _log $LOG_LEVEL_WARN "WARN" "$COLOR_WARN" "$*"
+}
+
+log_error() {
+    _log $LOG_LEVEL_ERROR "ERROR" "$COLOR_ERROR" "$*"
+}
+
+log_fatal() {
+    _log $LOG_LEVEL_FATAL "FATAL" "$COLOR_FATAL" "$*"
+}
+
+# Convenience function to log and exit with error code
+# Arguments:
+#   $1 - Error message
+#   $2 - (Optional) Exit code (default: 1)
+log_fatal_and_exit() {
+    local message="$1"
+    local exit_code="${2:-1}"
+
+    log_fatal "$message"
+    exit "$exit_code"
+}

--- a/lib/state_url_.sh
+++ b/lib/state_url_.sh
@@ -15,27 +15,47 @@ get_state_param() {
     local http_content
     local param_value
 
+    log_debug "Fetching parameter '$param_name' from URL: $url_to_fetch"
+
     # Fetch content using wget, suppressing output, allowing redirects.
+    log_debug "Executing wget command with max-redirect=5"
     http_content=$(wget --max-redirect=5 -q -O - "$url_to_fetch" 2>/dev/null)
-    if [ $? -ne 0 ]; then
+    local wget_exit_code=$?
+
+    if [ $wget_exit_code -ne 0 ]; then
+        log_error "Failed to fetch content from $url_to_fetch (wget exit code: $wget_exit_code)"
         echo "Error (get_state_param): Failed to fetch $url_to_fetch" >&2
         return 1
     fi
+
+    log_debug "Successfully fetched content from $url_to_fetch"
+    log_debug "Content length: $(echo "$http_content" | wc -c) characters"
 
     # Extract the parameter value.
     # grep for lines starting with "param_name=", then cut by '=' and get the 2nd field.
     # sed removes any backslashes (used for escaping in state.txt) and trailing 'Z'.
     # tr removes carriage returns and newlines.
+    log_debug "Extracting parameter '$param_name' using grep/cut/sed/tr pipeline"
     param_value=$(echo "$http_content" | grep "^${param_name}=" | cut -d'=' -f2 | sed 's/\\//g; s/Z$//' | tr -d '\r\n ')
 
     # Check if the parameter was actually found and has a value.
     if [ -z "$param_value" ]; then
-      # This check is important because grep might not find the line,
-      # or the value might legitimately be empty after processing.
-      # echo "Debug (get_state_param): Parameter '$param_name' not found or empty in $url_to_fetch" >&2
-      return 1 # Parameter not found or empty
+        # This check is important because grep might not find the line,
+        # or the value might legitimately be empty after processing.
+        # echo "Debug (get_state_param): Parameter '$param_name' not found or empty in $url_to_fetch" >&2
+        log_warn "Parameter '$param_name' not found or empty in response from $url_to_fetch"
+        log_debug "Available parameters in response:"
+        if [ -n "$http_content" ]; then
+            echo "$http_content" | grep "^[^=]*=" | cut -d'=' -f1 | while read -r available_param; do
+                log_debug "  - $available_param"
+            done
+        else
+            log_debug "  (no content received)"
+        fi
+        return 1 # Parameter not found or empty
     fi
 
+    log_debug "Successfully extracted parameter '$param_name' = '$param_value'"
     echo "$param_value"
     return 0
 }
@@ -54,17 +74,32 @@ get_sequence_file_url() {
     local sequence_number="$2"
     local padded_sequence_number
 
+    log_debug "Generating sequence file URL for base: '$effective_base_url', sequence: '$sequence_number'"
+
     # Validate that sequence_number is an integer.
     if ! [[ "$sequence_number" =~ ^[0-9]+$ ]]; then
+        log_error "Sequence number validation failed: '$sequence_number' is not a valid integer"
         echo "Error (get_sequence_file_url): Sequence number must be an integer. Got: '$sequence_number'" >&2
         return 1
     fi
 
+    log_debug "Sequence number validation passed: '$sequence_number'"
+
     # Format the sequence number to a 9-digit string, zero-padded.
     padded_sequence_number=$(printf "%09d" "$sequence_number")
+    log_debug "Padded sequence number: '$padded_sequence_number'"
 
     # Construct the path segments (e.g., 000/001/234).
+    local path_segment1="${padded_sequence_number:0:3}"
+    local path_segment2="${padded_sequence_number:3:3}"
+    local path_segment3="${padded_sequence_number:6:3}"
+
+    log_debug "Path segments: $path_segment1/$path_segment2/$path_segment3"
+
     # Remove a trailing slash from effective_base_url if present, before appending path.
-    echo "${effective_base_url%/}/${padded_sequence_number:0:3}/${padded_sequence_number:3:3}/${padded_sequence_number:6:3}.state.txt"
+    local final_url="${effective_base_url%/}/${path_segment1}/${path_segment2}/${path_segment3}.state.txt"
+
+    log_debug "Generated sequence file URL: $final_url"
+    echo "$final_url"
     return 0
 }

--- a/lib/url_parser_.sh
+++ b/lib/url_parser_.sh
@@ -19,17 +19,31 @@ parse_and_prepare_base_url() {
     local current_period="$2"
     local is_osm_like="$3"
 
+    log_debug "Starting URL parsing with parameters:"
+    log_debug "  input_url: '$input_url'"
+    log_debug "  current_period: '$current_period'"
+    log_debug "  is_osm_like: '$is_osm_like'"
+
     local base_dir
 
     # Remove potential query strings and fragments from the URL
     base_dir="${input_url%%[?#]*}"
+    log_debug "Removed query strings and fragments: '$base_dir'"
 
     # Phase 1: Normalize to a directory path by stripping known filenames.
     # This sed expression attempts to find and remove:
     #   - /<3digits>/<3digits>/<3digits>.state.txt (sequence file)
     #   - /state.txt (period state file)
     # and replaces them with a trailing slash, effectively getting the parent directory.
+    log_debug "Normalizing URL by removing known filenames"
+    local original_base_dir="$base_dir"
     base_dir=$(echo "$base_dir" | sed -E 's!(/[0-9]{3}/[0-9]{3}/[0-9]{3})?([/.]state\.txt)$!/!')
+
+    if [ "$original_base_dir" != "$base_dir" ]; then
+        log_debug "URL normalization changed: '$original_base_dir' -> '$base_dir'"
+    else
+        log_debug "URL normalization: no changes needed"
+    fi
 
     # Ensure the path ends with a slash for consistent processing,
     # if it's not empty and doesn't already have one.
@@ -37,34 +51,43 @@ parse_and_prepare_base_url() {
     #     base_dir+="/"
     # fi
 
-    if [[ "$is_osm_like" == "true" ]];then
+    if [[ "$is_osm_like" == "true" ]]; then
+        log_debug "Processing as OSM-like structure"
         # For OSM-like structures, the effective base URL should point to the period-specific directory
         # (e.g., .../replication/hour/).
 
         local expected_period_suffix="${current_period}/"
+        log_debug "Expected period suffix: '$expected_period_suffix'"
+
         # Check if the current base_dir already ends with the expected period suffix
         if [[ "$base_dir" == *"/$expected_period_suffix" ]]; then
             # It's already the correct period directory (e.g., https://host.com/repl/hour/).
-            : # Do nothing, base_dir is correctly formatted.
+            log_debug "URL already contains correct period suffix - no changes needed"
         else
             # Assume base_dir is the replication root (e.g., https://host.com/repl/)
             # and append the current_period to it.
+            log_debug "Appending period to base URL"
+            local old_base_dir="$base_dir"
             # Remove a trailing slash from base_dir if present, then add period and a new slash.
             base_dir="${base_dir%/}/${current_period}/"
+            log_debug "OSM-like URL construction: '$old_base_dir' -> '$base_dir'"
         fi
     else
+        log_debug "Processing as non-OSM-like structure"
         # For non-OSM-like structures, base_dir (after stripping filenames)
         # is already assumed to be the directory containing state.txt and sequence folders.
         # The 'current_period' variable is not used for further path construction here.
-        : # Do nothing, base_dir is assumed to be correct as is.
+        log_debug "Non-OSM-like structure: using base_dir as-is after normalization"
     fi
 
     # Final check to ensure the resulting URL ends with a slash,
     # if it's not empty and doesn't already have one.
     if [[ -n "$base_dir" && "${base_dir: -1}" != "/" ]]; then
+        log_debug "Adding trailing slash to final URL"
         base_dir+="/"
     fi
 
+    log_info "URL parsing completed successfully: '$input_url' -> '$base_dir'"
     echo "$base_dir"
     return 0
 }

--- a/lib/usage_.sh
+++ b/lib/usage_.sh
@@ -1,51 +1,201 @@
 #!/bin/bash
 
-# Displays usage information for the script.
-# Arguments:
-#   $1 - The script name (e.g., $0 from the main script).
-# Environment Variables:
-#   DEFAULT_URL_FOR_USAGE - The default replication URL to display in usage.
+# Color definitions for enhanced output (POSIX compatible)
+if [[ -t 1 ]] && command -v tput >/dev/null 2>&1; then
+    # Terminal supports colors
+    RED=$(tput setaf 1)
+    GREEN=$(tput setaf 2)
+    YELLOW=$(tput setaf 3)
+    BLUE=$(tput setaf 4)
+    PURPLE=$(tput setaf 5)
+    CYAN=$(tput setaf 6)
+    WHITE=$(tput setaf 7)
+    GRAY=$(tput setaf 8 2>/dev/null || tput setaf 7)
+    BOLD=$(tput bold)
+    DIM=$(tput dim 2>/dev/null || echo "")
+    UNDERLINE=$(tput smul)
+    RESET=$(tput sgr0)
+else
+    # No color support
+    RED="" GREEN="" YELLOW="" BLUE="" PURPLE="" CYAN="" WHITE="" GRAY=""
+    BOLD="" DIM="" UNDERLINE="" RESET=""
+fi
+
+# ASCII symbols for visual enhancement (compatible across shells)
+ARROW=">"
+BULLET="*"
+STAR="*"
+CHECK="+"
+GEAR="¤"
+INFO="i"
+WARNING="!"
+
+# Function to create divider
+print_divider() {
+    local char="${1:--}"
+    local width="${2:-78}"
+    local color="${3:-$CYAN}"
+
+    printf "${color}"
+    printf "%*s" "$width" | tr ' ' "$char"
+    printf "${RESET}\n"
+}
+
+# Function to create a header
+print_header() {
+    local title="$1"
+    local subtitle="$2"
+    local title_len=${#title}
+    local subtitle_len=${#subtitle}
+    local padding
+
+    echo
+    print_divider "=" 78 "$PURPLE"
+
+    # Center title
+    padding=$(( (78 - title_len) / 2 ))
+    printf "${BOLD}${WHITE}%*s%s${RESET}\n" "$padding" "" "$title"
+
+    # Center subtitle if provided
+    if [[ -n "$subtitle" ]]; then
+        padding=$(( (78 - subtitle_len) / 2 ))
+        printf "${DIM}${GRAY}%*s%s${RESET}\n" "$padding" "" "$subtitle"
+    fi
+
+    print_divider "=" 78 "$PURPLE"
+    echo
+}
+
+# Function to print styled sections
+print_section() {
+    local title="$1"
+    local icon="$2"
+    local color="${3:-$BLUE}"
+
+    printf "\n${BOLD}${color}${icon} %s${RESET}\n" "$title"
+    print_divider "-" 40 "$color"
+}
+
+# Function to print parameter with styling
+print_param() {
+    local param="$1"
+    local desc="$2"
+    local required="${3:-false}"
+
+    if [[ "$required" == "true" ]]; then
+        printf "  ${BOLD}${GREEN}%-16s${RESET} ${ARROW} %s\n" "$param" "$desc"
+    else
+        printf "  ${DIM}${BOLD}${YELLOW}%-16s${RESET} ${ARROW} %s\n" "$param" "$desc"
+    fi
+}
+
+# Function to print option with styling
+print_option() {
+    local option="$1"
+    local desc="$2"
+    local default="$3"
+
+    printf "  ${BOLD}${CYAN}%-25s${RESET} ${BULLET} %s" "$option" "$desc"
+    if [[ -n "$default" ]]; then
+        printf " ${DIM}${GRAY}(Default: %s)${RESET}" "$default"
+    fi
+    printf "\n"
+}
+
+# Function to print example with syntax highlighting
+print_example() {
+    local cmd="$1"
+    local desc="$2"
+
+    printf "  ${DIM}${GRAY}${BULLET}"
+    if [[ -n "$desc" ]]; then
+        printf " %s${RESET}" "$desc"
+    fi
+    printf "\n"
+    printf "  ${GREEN}%s${RESET}" "$cmd"
+    printf "\n\n"
+}
+
+# Function to print log level info
+print_log_level() {
+    local level="$1"
+    local desc="$2"
+    local color="$3"
+
+    printf "    ${BOLD}${color}%-8s${RESET} - %s\n" "$level" "$desc"
+}
+
+# Enhanced usage function with visual styling
 show_usage() {
-    local script_name="${1:-osm-diff-state.sh}" # Script name from the main file
+    local script_name="${1:-osm-diff-state.sh}"
     local default_repl_url="${DEFAULT_URL_FOR_USAGE:-https://planet.osm.org/replication/}"
 
-    cat <<USAGE
-Find OpenStreetMap replication file for a specific timestamp.
+    print_header "OpenStreetMap replication diff search tool" "Find OSM replication files by timestamp"
 
-Usage: $script_name <period> <timestamp> [replication_url] [options]
+    # Usage syntax
+    print_section "USAGE" "$GEAR" "$BLUE"
+    printf "  ${BOLD}${WHITE}%s${RESET} ${GREEN}<period>${RESET} ${GREEN}<timestamp>${RESET} ${DIM}${YELLOW}[replication_url]${RESET} ${DIM}${YELLOW}[options]${RESET}\n\n" "$script_name"
 
-Parameters:
-    period          - Replication period (day, hour, minute).
-    timestamp       - Date and time in YYYY-MM-DD[THH:MM:SS] format.
-    replication_url - (Optional) URL to the replication data.
-                      This can be the root of replication (e.g., https://planet.osm.org/replication/),
-                      a specific period directory (e.g., .../replication/hour/),
-                      or a path to a state.txt or sequence file.
-                      Default: ${default_repl_url}
+    # Parameters section
+    print_section "PARAMETERS" "$ARROW" "$GREEN"
+    print_param "period" "Replication period (${BOLD}day, hour, minute${RESET})" "true"
+    print_param "timestamp" "Date and time in ${UNDERLINE}${BOLD}YYYY-MM-DD${DIM}[<T| >[HH[:MM[:SS]]]]${RESET} format" "true"
+    print_param "replication_url" "URL to replication data ${DIM}(Optional)${RESET}" "false"
 
-Options:
-    --osm-like[=<true|false>] - Define if the replication_url structure is like planet.osm.org.
-                                If true, <period> is expected as a path segment (e.g., .../replication/<period>/).
-                                If false, replication_url directly points to a directory containing
-                                state.txt and sequence number folders for the specified <period>.
-                                The <period> argument is used for context but not to derive path segments
-                                from the replication_url after initial parsing.
-                                Providing just '--osm-like' without a value is equivalent to '--osm-like=true'.
-                                (Default: true)
-    -h, --help                - Show this help message.
+    printf "\n  ${DIM}${GRAY}${INFO} Default URL: ${UNDERLINE}%s${RESET}${DIM}${GRAY}${RESET}\n" "$default_repl_url"
+    printf "  ${DIM}${GRAY}${INFO} URL can be root, period directory, or direct state.txt path${RESET}\n"
 
-Examples:
-    $script_name day "2024-05-16"
-    $script_name hour "2024-05-16T12:00" "https://planet.osm.org/replication/" --osm-like=true
-    $script_name minute "2024-05-16 12:00:00" "https://custom.server/osm/minute-diffs/" --osm-like=false
-    $script_name hour "2024-05-16T12:00" # Uses default URL and osm-like structure
-    $script_name day "2024-05-16" "https://my-mirror.com/planet/day/000/001/234.state.txt" # Will parse correctly
+    # Options section
+    print_section "OPTIONS" "$GEAR" "$CYAN"
+    print_option "--osm-like[=<true|false>]" "Define replication URL structure" "true"
+    print_option "--log-level=<level>" "Set logging level ${DIM}(debug|info|warn|error|fatal)${RESET}" "info"
+    print_option "-v, --verbose" "Enable debug logging"
+    print_option "-q, --quiet" "Show only errors"
+    print_option "-h, --help" "Show this help message"
 
-Description:
-    This script finds the closest OpenStreetMap replication file for a given timestamp
-    using binary search (bisection). It returns the full URL to the found state file.
-    The script will find the nearest state file with a timestamp less than or equal to
-    the requested time. The interpretation of 'replication_url' depends on the --osm-like flag.
-USAGE
+    # Logging section
+    print_section "LOGGING LEVELS" "$INFO" "$PURPLE"
+    printf "  ${DIM}${GRAY}${INFO} All logs go to stderr, results to stdout${RESET}\n\n"
+    print_log_level "debug" "Detailed debugging information" "$GRAY"
+    print_log_level "info" "General progress information" "$BLUE"
+    print_log_level "warn" "Warning messages" "$YELLOW"
+    print_log_level "error" "Error messages only" "$RED"
+    print_log_level "fatal" "Critical errors only" "$RED"
+
+    # Examples section
+    print_section "EXAMPLES" "$STAR" "$GREEN"
+    print_example "$script_name day \"2024-05-16\"" "Basic daily replication"
+    print_example "$script_name hour \"2024-05-16T12:00\" --verbose" "Hourly with debug output"
+    print_example "$script_name minute \"2024-05-16 12:00:00\" --log-level=debug" "Minute-level with specific log level"
+    print_example "$script_name hour \"2024-05-16T12:00\" \"$default_repl_url\" --osm-like=true --quiet" "Custom URL with OSM structure"
+    print_example "$script_name minute \"2024-05-16 12:00:00\" \"https://custom.server/osm/minute-diffs/\" --osm-like=false" "Non-OSM structure"
+    print_example "$script_name day \"2024-05-16\" \"https://my-mirror.com/planet/day/000/001/234.state.txt\"" "Direct state file URL"
+
+    # Description section
+    print_section "DESCRIPTION" "(I)" "$BLUE"
+    cat << 'DESC'
+  This script finds the closest OpenStreetMap replication file for
+  a given timestamp using binary search (bisection). It returns the
+  full URL to the found state file.
+
+  Key Features:
+  * Finds nearest state file with timestamp <= requested time
+  * Supports various replication URL structures
+  * Configurable logging levels
+  * Binary search for efficient file discovery
+
+  Important Notes:
+  * The --osm-like flag determines URL interpretation
+  * All logging goes to stderr to preserve pipeline compatibility
+  * Main result is always printed to stdout regardless of log level
+DESC
+
+    # Footer
+    echo
+    print_divider "-" 78 "$DIM"
+    printf "${DIM}${GRAY}%s${RESET}\n" "For more help, visit: https://wiki.openstreetmap.org/wiki/Planet.osm/diffs"
+    print_divider "-" 78 "$DIM"
+    echo
+
     exit 1
 }

--- a/lib/validation_.sh
+++ b/lib/validation_.sh
@@ -15,10 +15,16 @@ validate_period() {
     # Use provided list or a default; ensure spaces around for robust matching.
     local valid_options=" ${VALID_PERIODS_LIST:-day hour minute} "
 
+    log_debug "Validating period: '$period_to_validate'"
+
     if [[ "$valid_options" == *" $period_to_validate "* ]]; then
+        log_debug "Period validation successful: '$period_to_validate' is valid"
         return 0 # Period is valid
     else
-        echo "Error (validate_period): Period must be one of: ${valid_options}" >&2
+        local error_msg="Period must be one of: ${valid_options}"
+        log_error "Period validation failed: '$period_to_validate' is not valid"
+        log_error "Available periods: $valid_options"
+        # echo "Error (validate_period): $error_msg" >&2
         return 1 # Period is invalid
     fi
 }

--- a/osm-diff-state.sh
+++ b/osm-diff-state.sh
@@ -8,6 +8,7 @@ LIB_DIR="$(dirname "$0")/lib"
 
 # Source helper functions.
 # Ensure these files exist in the LIB_DIR.
+source "${LIB_DIR}/logging_.sh"      # Must be sourced first
 source "${LIB_DIR}/usage_.sh"
 source "${LIB_DIR}/date_.sh"
 source "${LIB_DIR}/validation_.sh"
@@ -40,52 +41,58 @@ find_state_file() {
     local target_timestamp_str="$2"
     local period="$3" # This is the period argument passed to the script.
 
+    log_debug "Starting find_state_file with URL: $effective_base_url, target: $target_timestamp_str, period: $period"
+
     # Construct URL for the current (latest) state.txt for the given period/data source.
     local current_period_state_txt_url="${effective_base_url%/}/state.txt"
+    log_debug "Current state URL: $current_period_state_txt_url"
 
     # Check either effective_base_url or current_period_state_txt_url for accessibility.
     # This is a more general check, as the state.txt might not exist but the base URL is valid.
+    log_info "Checking URL accessibility: $effective_base_url"
     if ! check_url_accessibility "$effective_base_url"; then
-        # Error message is printed by check_url_accessibility
-        exit 1
+        log_fatal_and_exit "URL accessibility check failed for: $effective_base_url" 1
     fi
+    log_debug "URL accessibility check passed"
+
     # If the above passes, state.txt itself might still be missing,
     # but at least the server/path is generally responsive.
 
     local latest_sequence_number
+    log_info "Fetching latest sequence number from: $current_period_state_txt_url"
     latest_sequence_number=$(get_state_param "$current_period_state_txt_url" "sequenceNumber") || {
-        echo "Error: Failed to get current 'sequenceNumber' from $current_period_state_txt_url" >&2
-        echo "       This could be due to a missing state.txt, network issues not caught by the initial check, or incorrect URL." >&2
+        log_error "Failed to get current 'sequenceNumber' from $current_period_state_txt_url"
+        log_error "This could be due to a missing state.txt, network issues not caught by the initial check, or incorrect URL."
         exit 1
     }
+    log_debug "Latest sequence number: $latest_sequence_number"
 
     local latest_timestamp_str
+    log_info "Fetching latest timestamp from: $current_period_state_txt_url"
     latest_timestamp_str=$(get_state_param "$current_period_state_txt_url" "timestamp") || {
-        echo "Error: Failed to get current 'timestamp' from $current_period_state_txt_url" >&2
-        exit 1
+        log_fatal_and_exit "Failed to get current 'timestamp' from $current_period_state_txt_url" 1
     }
+    log_debug "Latest timestamp: $latest_timestamp_str"
 
     local latest_epoch
     latest_epoch=$(to_epoch "$latest_timestamp_str") || exit 1 # Convert latest state's time to epoch.
+    log_debug "Latest epoch: $latest_epoch"
 
     local target_epoch
     target_epoch=$(to_epoch "$target_timestamp_str") || exit 1 # Convert target time to epoch; exit on failure.
-
-    # echo "DEBUG: target_timestamp_str='$target_timestamp_str', target_epoch=$target_epoch"
-    # echo "DEBUG: latest_timestamp_str='$latest_timestamp_str', latest_epoch=$latest_epoch"
+    log_debug "Target epoch: $target_epoch"
 
     # Check if the target timestamp is in the future compared to the latest available state.
     if [ "$target_epoch" -gt "$latest_epoch" ]; then
-        echo "Warning: Requested time '$target_timestamp_str' is in the future. Using latest available state ('$latest_timestamp_str')." >&2
+        log_warn "Requested time '$target_timestamp_str' is in the future. Using latest available state ('$latest_timestamp_str')."
         # Check accessibility of the specific sequence file URL before printing
         local latest_seq_url
         latest_seq_url=$(get_sequence_file_url "$effective_base_url" "$latest_sequence_number")
         if [ $? -eq 0 ] && check_url_accessibility "$latest_seq_url" 5 1; then # Shorter timeout/retry for this specific file
+             log_info "Returning latest sequence file URL: $latest_seq_url"
              echo "$latest_seq_url"
         else
-            echo "Error: Latest sequence file URL ($latest_seq_url) appears inaccessible or could not be generated." >&2
-            # Fallback or error further? For now, error.
-            exit 1
+            log_fatal_and_exit "Latest sequence file URL ($latest_seq_url) appears inaccessible or could not be generated." 1
         fi
         return 2 # Return special code for future timestamp.
     fi
@@ -101,17 +108,19 @@ find_state_file() {
             local divider=60 # Seconds in a minute.
             ;;
         *)
-            echo "Error (finding divider): Unknown period '$period'" >&2
-            exit 1
+            log_fatal_and_exit "Unknown period '$period'" 1
             ;;
     esac
 
     local target_sequence_number=$(( $latest_sequence_number - ( $latest_epoch - $target_epoch ) / $divider - 1 ))
+    log_debug "Calculated target sequence number: $target_sequence_number"
 
     # --- Binary search for the sequence file using the library function ---
     # The initial low bound is the calculated sequence number.
     local initial_low_bound=$((10#$target_sequence_number))  # Ensure low_bound is treated as decimal.
     local initial_high_bound=$((10#$latest_sequence_number)) # Ensure high_bound is treated as decimal.
+
+    log_info "Starting binary search with bounds: [$initial_low_bound, $initial_high_bound]"
 
     local found_sequence_number
     found_sequence_number=$(perform_binary_search_for_sequence \
@@ -123,26 +132,26 @@ find_state_file() {
     if [ $? -ne 0 ]; then # Check return status of perform_binary_search_for_sequence
         # The search function itself would have printed an error if result_sequence_number was -1.
         # Or if it encountered a more critical error.
-        echo "Error: Binary search did not find a suitable sequence number for '$target_timestamp_str' at $effective_base_url" >&2
-        exit 1
+        log_fatal_and_exit "Binary search did not find a suitable sequence number for '$target_timestamp_str' at $effective_base_url" 1
     fi
 
     # If perform_binary_search_for_sequence returned 0, $found_sequence_number contains the result.
     if [ "$found_sequence_number" -eq -1 ] || [ -z "$found_sequence_number" ]; then
          # This case should ideally be caught by the return status check above,
          # but as a safeguard if the search function echoed -1 for some reason AND returned 0.
-        echo "Error: Binary search logic error or no sequence found for '$target_timestamp_str' at $effective_base_url" >&2
-        exit 1
+        log_fatal_and_exit "Binary search logic error or no sequence found for '$target_timestamp_str' at $effective_base_url" 1
     fi
+
+    log_info "Binary search found sequence number: $found_sequence_number"
 
     # Before printing the final URL, one last check on its accessibility could be done
     local final_url
     final_url=$(get_sequence_file_url "$effective_base_url" "$found_sequence_number")
     if [ $? -eq 0 ] && check_url_accessibility "$final_url" 5 1; then # Shorter timeout/retry
+        log_info "Final result URL: $final_url"
         echo "$final_url"
     else
-        echo "Error: The determined sequence file URL ($final_url) appears inaccessible or could not be generated." >&2
-        exit 1
+        log_fatal_and_exit "The determined sequence file URL ($final_url) appears inaccessible or could not be generated." 1
     fi
     return 0
 }
@@ -157,7 +166,7 @@ user_provided_url=""
 osm_like_structure="true" # Default value for osm-like behavior.
 
 # Parse command-line arguments.
-# This loop handles options (like --osm-like, -h) and collects positional arguments.
+# This loop handles options (like --osm-like, -h, --log-level) and collects positional arguments.
 declare -a positional_args=() # Array to store positional arguments.
 while [[ $# -gt 0 ]]; do
     case "$1" in
@@ -170,7 +179,8 @@ while [[ $# -gt 0 ]]; do
             if [[ "$osm_like_value" =~ ^(true|false)$ ]]; then
                 osm_like_structure="$osm_like_value"
             else
-                echo -e "Error: Invalid value for --osm-like. Must be 'true' or 'false'. Got: '$osm_like_value'\n" >&2
+                log_error "Invalid value for --osm-like. Must be 'true' or 'false'. Got: '$osm_like_value'."
+                echo ""
                 # Pass $0 to show_usage for correct script name display.
                 DEFAULT_URL_FOR_USAGE="${DEFAULT_INPUT_URL}" show_usage "$0"
                 exit 1
@@ -178,12 +188,42 @@ while [[ $# -gt 0 ]]; do
         fi
         shift # Move past argument=value
         ;;
+        --log-level*)
+        if [[ "$1" == "--log-level" ]]; then
+            if [[ $# -lt 2 ]]; then
+                # echo "Error: --log-level requires a value (debug, info, warn, error, fatal)" >&2
+                log_error "--log-level requires a value (debug, info, warn, error, fatal)"
+                exit 1
+            fi
+            shift # Move to the value
+            log_level_value="$1"
+        else
+            # Extract the value after '=' if present.
+            log_level_value="${1#*=}" # Extract value after '='
+        fi
+
+        if ! set_log_level "$log_level_value"; then
+            exit 1
+        fi
+        shift # Move past argument or value
+        ;;
+        -v|--verbose)
+        # Shortcut for debug level
+        set_log_level "debug"
+        shift
+        ;;
+        -q|--quiet)
+        # Shortcut for error level only
+        set_log_level "error"
+        shift
+        ;;
         -h|--help)
         DEFAULT_URL_FOR_USAGE="${DEFAULT_INPUT_URL}" show_usage "$0"
         exit 0
         ;;
         -*) # Unknown option
-        echo -e "Error: Unknown option: $1\n" >&2
+        log_error "Unknown option: $1"
+        echo ""
         DEFAULT_URL_FOR_USAGE="${DEFAULT_INPUT_URL}" show_usage "$0"
         exit 1
         ;;
@@ -196,10 +236,13 @@ done
 # Restore positional arguments for further processing.
 set -- "${positional_args[@]}"
 
+log_debug "Script started with log level: $LOG_LEVEL"
+log_debug "Positional arguments: ${positional_args[*]}"
 
 # Assign positional arguments after options have been processed.
 if [ ${#positional_args[@]} -lt 2 ]; then
-    echo -e "Error: Missing required arguments: <period> and <timestamp>.\n" >&2
+    log_error "Expected at least 2 positional arguments: <period> and <timestamp>."
+    echo ""
     DEFAULT_URL_FOR_USAGE="${DEFAULT_INPUT_URL}" show_usage "$0"
     exit 1
 fi
@@ -213,26 +256,23 @@ else
     user_provided_url="$DEFAULT_INPUT_URL"
 fi
 
+log_info "Script parameters - Period: $arg_period, Timestamp: $arg_timestamp"
+log_info "Using URL: $user_provided_url"
+log_debug "OSM-like structure: $osm_like_structure"
+
 # Validate the period argument.
 # VALID_PERIODS_LIST is used by validate_period from lib/validation_.sh
 validate_period "$arg_period" || exit 1 # validate_period prints its own error.
 
 # Generate the effective base URL using the parsed arguments.
 # This URL points directly to the directory where state.txt and sequence folders are expected.
+log_info "Parsing and preparing base URL"
 effective_base_url=$(parse_and_prepare_base_url "$user_provided_url" "$arg_period" "$osm_like_structure")
 if [ $? -ne 0 ] || [ -z "$effective_base_url" ]; then # Check return status and if URL is empty
-    echo "Error: Could not determine a valid base URL from '$user_provided_url'." >&2
-    exit 1
+    log_fatal_and_exit "Could not determine a valid base URL from '$user_provided_url'." 1
 fi
 
-# Debugging output (can be commented out for production).
-# echo "--- Debug Info ---"
-# echo "  User Input URL: $user_provided_url"
-# echo "  Period: $arg_period"
-# echo "  Timestamp: $arg_timestamp"
-# echo "  OSM-like: $osm_like_structure"
-# echo "  Effective Base URL for Operations: $effective_base_url"
-# echo "--------------------"
+log_info "Effective base URL: $effective_base_url"
 
 # Call the main function to find and output the state file URL.
 find_state_file "$effective_base_url" "$arg_timestamp" "$arg_period"


### PR DESCRIPTION
This PR adds high-degree verbose logging from `debug` to `fatal`. The standard logging level is `info`.

You can suppress the log output using the `--quiet` or `-q` options, which are shortened versions of `--log-level=error`.